### PR TITLE
Fix exception docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.1.2] - 2018-06-20
+
 ### Fixed
 
 - exception documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- exception documentation
+
 ## [0.1.1] - 2018-05-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/react",
   "description": "React DOM helpers for testing big",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "repository": "https://github.com/bigtestjs/react",
   "main": "dist/umd/index.js",

--- a/src/context.js
+++ b/src/context.js
@@ -30,7 +30,7 @@ export function setContext(newContext) {
  * @param {String} key - The key of the value to retrieve
  * @param {String|Boolean} [error] - Specific error message to throw
  * @returns Value of `key` within the current context
- * @throws Error when `key` is not fonud in the current context
+ * @throws {Error} when `key` is not fonud in the current context
  */
 export function getContext(key, error) {
   if (typeof error === 'undefined') {

--- a/src/visit.js
+++ b/src/visit.js
@@ -15,7 +15,7 @@ import { getContext } from './context';
  *
  * @function visit
  * @param {Object|String} location - Argument for `history.push()`
- * @throws Error When `setupAppForTesting` was not called
+ * @throws {Error} When `setupAppForTesting` was not called
  */
 export function visit(location) {
   getContext('history').push(location);
@@ -37,7 +37,7 @@ export function visit(location) {
  * ```
  *
  * @function goBack
- * @throws Error When `setupAppForTesting` was not called
+ * @throws {Error} When `setupAppForTesting` was not called
  */
 export function goBack() {
   getContext('history').goBack();
@@ -60,7 +60,7 @@ export function goBack() {
  * ```
  *
  * @function goForward
- * @throws Error When `setupAppForTesting` was not called
+ * @throws {Error} When `setupAppForTesting` was not called
  */
 export function goForward() {
   getContext('history').goForward();
@@ -80,7 +80,7 @@ export function goForward() {
  * ```
  *
  * @returns {Object} Current history location object
- * @throws Error When `setupAppForTesting` was not called
+ * @throws {Error} When `setupAppForTesting` was not called
  */
 export function location() {
   return getContext('history').location;


### PR DESCRIPTION
## Purpose

Where we document errors, the type is meant to be encapsulated by `{}`. Since that is missing, the `Error` is part of the description which does not look good on the documentation website.

Currently bigtestjs/bigtestjs.io#42 fails because this package's documentation fails to build. Instead of adding conditional checks in the templates there, we can enforce that the type be correct.

## Approach

Wrap the types in `{}` and release a new version so that branch may be updated.

### Screenshots

![image](https://user-images.githubusercontent.com/5005153/41689974-0330551e-74b9-11e8-9d52-8ce067851da8.png)

![image](https://user-images.githubusercontent.com/5005153/41690235-239994e0-74ba-11e8-87f1-77786f7f80b6.png)
